### PR TITLE
To cope with more than 1 network interface

### DIFF
--- a/afraid-dyndns
+++ b/afraid-dyndns
@@ -41,7 +41,7 @@ function Fail
 function AirportIP
 {
 	typeset router=$(netstat -nr | \
-			awk '/^0.0.0.0|^default/ {print $2}') \
+			awk '/^0.0.0.0|^default/ {print $2; exit}') \
 			|| return 1
 	typeset gw=$(snmpwalk -Os -c public -v 1 "$router" \
 				iso.3.6.1.2.1.4.21.1.7.0.0.0.0 | \


### PR DESCRIPTION
If a machine is connecting to the airport extreme to more than 1 interface (Wi-Fi and ethernet),
then there will be two rows appearing in the router variable, will choose the first one after the change
